### PR TITLE
feat: 대시보드에서 최신공지 하나 보여주는기능 추가 & 누르면 공지사항으로 이동.

### DIFF
--- a/src/views/dashboard/DashboardMain.vue
+++ b/src/views/dashboard/DashboardMain.vue
@@ -2,6 +2,12 @@
     <AppPageLayout>
         <div class="p-6 space-y-8">
             <!-- 헤더 -->
+            <div class="bg-yellow-50 border border-yellow-300 text-yellow-800 rounded-lg py-3 px-6 mx-auto mb-6 max-w-3xl
+         flex justify-center items-center gap-3 cursor-pointer hover:bg-yellow-100 transition"
+                @click="$router.push('/announcement')">
+                <span class="text-lg">📢</span>
+                <span class="font-medium truncate">[공지] {{ latestAnnouncement?.title || '공지사항을 확인하세요!' }}</span>
+            </div>
             <div class="flex items-center justify-between border-b pb-4">
                 <div>
                     <h1 class="text-2xl font-semibold text-gray-800">입출고 및 반품 현황</h1>
@@ -190,6 +196,9 @@ import { ref, onMounted, nextTick } from 'vue'
 import AppPageLayout from '@/layouts/AppPageLayout.vue'
 import { Doughnut, Bar } from 'vue-chartjs'
 import { Chart as ChartJS, Title, Tooltip, Legend, ArcElement, BarElement, CategoryScale, LinearScale, } from 'chart.js'
+import announcementApi from '@/api/announcement'
+
+const latestAnnouncement = ref(null)
 const filters = ['기간']
 ChartJS.register(Title, Tooltip, Legend, ArcElement, BarElement, CategoryScale, LinearScale)
 
@@ -312,7 +321,19 @@ const vendorReturnOptions = ref({
 const pieChart = ref(null)
 const barChart = ref(null)
 
+const fetchLatestAnnouncement = async () => {
+    try {
+        const response = await announcementApi.announcementList(0, 1);
+        if (response && response.results && response.results.content && response.results.content.length > 0) {
+            latestAnnouncement.value = response.results.content[0];
+        }
+    } catch (error) {
+        console.error('Error fetching latest announcement:', error);
+    }
+};
+
 onMounted(async () => {
+    fetchLatestAnnouncement()
     await nextTick()
     pieChart.value?.chart.reset()
     pieChart.value?.chart.update()


### PR DESCRIPTION
# 🧩 Issue

## 📝 요약
> 대시보드 상단에 공지사항 추가

## 🔍 변경 사항
-제일 최신 공지사항 하나 나오게 추가했고 누르면 공지사항 목록으로 이동되게 했습니다.

## ✅ 체크리스트
- [ ] 코드 컨벤션을 준수 했는가?
- [ ] 커밋 내용에 시크릿 키 등의 공유되지 말아야 할 것들을 제거 했는가?

## 💬 기타 공유사항
> 리뷰어에게 전달할 추가 맥락이나 참고사항