### PR TITLE
feat:중요 공지 상단에 고정시키는 기능 추가

### DIFF
--- a/src/api/announcement/index.js
+++ b/src/api/announcement/index.js
@@ -64,17 +64,19 @@ const announcementDelete = async (id) => {
   return data
 }
 
-const announcementEdit = async (id) => {
+const announcementEdit = async (id, payload) => {
   let data = {}
-  let url = `/api/announcement/${id}`
+  const url = `/api/announcement/${id}`
 
   await api
-    .patch(url)
+    .patch(url, payload, {
+      headers: { 'Content-Type': 'application/json' },
+    })
     .then((res) => {
       data = res.data
     })
     .catch((error) => {
-      data = error.data
+      data = error.response?.data || error
     })
 
   return data

--- a/src/views/announcement/AnnouncementCreate.vue
+++ b/src/views/announcement/AnnouncementCreate.vue
@@ -17,7 +17,7 @@
                     <div class="flex items-center justify-between mb-2">
                         <label class="block text-sm font-medium text-gray-700">제목</label>
                         <label class="flex items-center gap-2 cursor-pointer">
-                            <input v-model="form.isPinned" type="checkbox"
+                            <input v-model="form.pinned" type="checkbox"
                                 class="w-4 h-4 text-red-600 border-gray-300 rounded focus:ring-red-500" />
                             <span class="text-sm font-medium text-red-600">중요 공지 (상단 고정)</span>
                         </label>
@@ -76,7 +76,7 @@ const router = useRouter()
 const form = ref({
     title: '',
     content: '',
-    isPinned: false,
+    pinned: false,
     targetRoles: [],
 })
 

--- a/src/views/announcement/AnnouncementEdit.vue
+++ b/src/views/announcement/AnnouncementEdit.vue
@@ -18,6 +18,12 @@
 
         <section v-if="announcement"
             class="bg-white border border-gray-200 rounded-xl shadow-sm p-6 md:p-8 space-y-6 max-w-4xl mx-auto">
+            <!-- 중요 공지 체크박스 -->
+            <div class="flex items-center gap-2">
+                <input id="pinned" type="checkbox" v-model="announcement.pinned"
+                    class="w-4 h-4 text-primary-600 border-gray-300 rounded focus:ring-primary-500" />
+                <label for="pinned" class="text-sm text-gray-700">중요 공지로 표시</label>
+            </div>
             <!-- 제목 -->
             <div>
                 <label class="block text-sm font-medium text-gray-700 mb-2">제목</label>
@@ -31,6 +37,8 @@
                 <textarea v-model="announcement.content" rows="10"
                     class="w-full border border-gray-300 rounded-lg px-4 py-3 focus:outline-none focus:ring-2 focus:ring-primary-500"></textarea>
             </div>
+
+
         </section>
 
         <!-- ✅ 수정 완료 모달 -->
@@ -92,11 +100,14 @@ const handleUpdate = async () => {
         const payload = {
             title: announcement.value.title,
             content: announcement.value.content,
+            pinned: announcement.value.pinned, // ✅ 중요 공지 여부 함께 전송
         }
 
-        const res = await announcementApi.announcementUpdate(route.params.id, payload)
+        const res = await announcementApi.announcementEdit(route.params.id, payload)
         if (res?.success) {
-            showSuccessModal.value = true // ✅ 모달 열기
+            showSuccessModal.value = true
+            alert('수정에 성공했습니다.')
+            router.push(`/announcement`)
         } else {
             alert('수정에 실패했습니다.')
         }

--- a/src/views/announcement/Announcemnet.vue
+++ b/src/views/announcement/Announcemnet.vue
@@ -31,13 +31,26 @@
                 </div>
             </div>
 
-            <!-- 테이블 -->
             <TableComp :columns="columns" :data="filteredList" class="min-h-[400px]">
                 <template #cell="{ row, col }">
+                    <!-- 제목 컬럼 -->
                     <span v-if="col.key === 'title'" class="text-indigo-600 hover:underline cursor-pointer"
                         @click="goDetail(row)">
                         {{ row[col.key] }}
                     </span>
+
+                    <!-- 번호 컬럼: pinned면 '중요' 버튼 -->
+                    <template v-else-if="col.key === 'id'">
+                        <div class="flex justify-center">
+                            <ButtonComp v-if="row.pinned" color="danger" size="sm"
+                                class="font-semibold cursor-default select-none">
+                                중요
+                            </ButtonComp>
+                            <span v-else class="text-center w-full">{{ row[col.key] }}</span>
+                        </div>
+                    </template>
+
+                    <!-- 기본 -->
                     <span v-else>{{ row[col.key] }}</span>
                 </template>
             </TableComp>
@@ -93,6 +106,7 @@ const fetchAnnouncements = async () => {
         title: item.title,
         name: item.name,
         createdAt: formatDate(item.createdAt),
+        pinned: item.pinned
     }))
 
     announcementList.value = list


### PR DESCRIPTION
# 🧩 Issue
* #64 
## 📝 요약
> 중요 공지면 상단에 나오게 구현

## 🔍 변경 사항
- 중요 공지상태면 정렬할 때 제일먼저오게하고 번호 대신에 (중요) 이렇게 나오게 구현함
- close #64 

## ✅ 체크리스트
- [ ] 코드 컨벤션을 준수 했는가?
- [ ] 커밋 내용에 시크릿 키 등의 공유되지 말아야 할 것들을 제거 했는가?

## 💬 기타 공유사항
