### PR TITLE
feat:asn페이지 구현 초안

### DIFF
--- a/src/api/asn/index.js
+++ b/src/api/asn/index.js
@@ -1,0 +1,58 @@
+import api from '@/plugin/axiosInterceptor.js'
+
+// Vendor ASN 수락 전송
+const vendorAsnSend = async (req) => {
+  let data = {}
+  const url = '/api/vendor/asn'
+
+  await api
+    .post(url, req)
+    .then((res) => {
+      data = res.data
+    })
+    .catch((error) => {
+      data = error.response?.data || error.data
+    })
+
+  return data
+}
+
+// Vendor ASN 거절 전송
+const vendorAsnReject = async (req) => {
+  let data = {}
+  const url = '/api/vendor/asn/reject'
+
+  await api
+    .post(url, req)
+    .then((res) => {
+      data = res.data
+    })
+    .catch((error) => {
+      data = error.response?.data || error.data
+    })
+
+  return data
+}
+
+// Vendor 발주 목록 조회 (※ 현재 백엔드에 없으므로 임시 더미 or 주석 처리 가능)
+const vendorPurchaseOrderReadAll = async (keyword = '') => {
+  let data = {}
+  const url = '/api/vendor/purchase-orders'
+
+  await api
+    .get(url, { params: { keyword } })
+    .then((res) => {
+      data = res.data
+    })
+    .catch((error) => {
+      data = error.response?.data || error.data
+    })
+
+  return data
+}
+
+export default {
+  vendorAsnSend,
+  vendorAsnReject,
+  vendorPurchaseOrderReadAll,
+}

--- a/src/api/franchise/index.js
+++ b/src/api/franchise/index.js
@@ -1,78 +1,89 @@
-import api from "@/plugin/axiosInterceptor.js";
+import api from '@/plugin/axiosInterceptor.js'
 
 const franchiseCreate = async (req) => {
-    let data = {};
-    let url = '/api/franchises';
+  let data = {}
+  let url = '/api/franchises'
 
-    await api.post(url, req)
-        .then((res) => {
-            data = res.data;
-        })
-        .catch((error) => {
-            data = error.data;
-        });
+  await api
+    .post(url, req)
+    .then((res) => {
+      data = res.data
+    })
+    .catch((error) => {
+      data = error.data
+    })
 
-    return data;
-};
+  return data
+}
 
 const franchiseRead = async (id) => {
-    let data = {};
-    let url = `/api/franchises/${id}`;
+  let data = {}
+  let url = `/api/franchises/${id}`
 
-    await api.get(url)
-        .then((res) => {
-            data = res.data;
-        })
-        .catch((error) => {
-            data = error.data;
-        });
+  await api
+    .get(url)
+    .then((res) => {
+      data = res.data
+    })
+    .catch((error) => {
+      data = error.data
+    })
 
-    return data;
-};
+  return data
+}
 
 const franchiseReadAll = async (page, size) => {
-    let data = {};
-    let url = '/api/franchises/list';
+  let data = {}
+  let url = '/api/franchises/list'
 
-    await api.get(url, {params: {page, size}})
-        .then((res) => {
-            data = res.data;
-        })
-        .catch((error) => {
-            data = error.data;
-        });
+  await api
+    .get(url, { params: { page, size } })
+    .then((res) => {
+      data = res.data
+    })
+    .catch((error) => {
+      data = error.data
+    })
 
-    return data;
-};
+  return data
+}
 
-const franchiseUpdate = async (id) => {
-    let data = {};
-    let url = `/api/franchises/${id}`;
+const franchiseUpdate = async (id, req) => {
+  let data = {}
+  const url = `/api/franchises/${id}`
 
-    await api.patch(url)
-        .then((res) => {
-            data = res.data;
-        })
-        .catch((error) => {
-            data = error.data;
-        });
+  await api
+    .patch(url, req)
+    .then((res) => {
+      data = res.data
+    })
+    .catch((error) => {
+      data = error.response?.data || error.data
+    })
 
-    return data;
-};
+  return data
+}
 
 const franchiseDelete = async (id) => {
-    let data = {};
-    let url = `/api/franchises/${id}`;
+  let data = {}
+  let url = `/api/franchises/${id}`
 
-    await api.delete(url)
-        .then((res) => {
-            data = res.data;
-        })
-        .catch((error) => {
-            data = error.data;
-        });
+  await api
+    .delete(url)
+    .then((res) => {
+      data = res.data
+    })
+    .catch((error) => {
+      data = error.data
+    })
 
-    return data;
-};
+  return data
+}
 
-export default {franchiseCreate, franchiseRead, franchiseReadAll, franchiseUpdate, franchiseDelete};
+export default {
+  franchiseCreate,
+  franchiseRead,
+  franchiseReadAll,
+  franchiseUpdate,
+  franchiseDelete,
+}

--- a/src/components/common/AppSideBar.vue
+++ b/src/components/common/AppSideBar.vue
@@ -77,6 +77,7 @@ const munus = [
   { label: '가맹점(Franchise)', icon: 'handshake', route: '/franchise' },
   { label: '직원 관리', icon: 'assignment_ind', route: '/employee' },
   { label: '작업 관리', icon: 'task', route: '/task/list' },
+  { label: 'ASN', icon: 'task', route: '/asn/vendor' },
   { label: '물류창고', icon: 'warehouse', route: '/warehouse' },
   { label: '모달 테스트', icon: 'frame_bug', route: '/modaltest' },
   { label: '테스트', icon: 'frame_bug', route: '/test' },

--- a/src/components/common/ModalComp.vue
+++ b/src/components/common/ModalComp.vue
@@ -9,6 +9,10 @@ const props = defineProps({
     type: Boolean,
     default: true,
   },
+  size: {
+    type: String,
+    default: 'max-w-md',
+  },
 })
 const emit = defineEmits(['close'])
 
@@ -37,7 +41,10 @@ onUnmounted(() => document.removeEventListener('keydown', handleEsc))
     >
       <!-- 모달 본문 -->
       <div
-        class="relative bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-700 p-8 rounded-2xl shadow-2xl w-full max-w-md"
+        :class="[
+          'relative bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-700 p-8 rounded-2xl shadow-2xl w-full',
+          size, // ✅ 이제 문자열로 받아서 Tailwind 클래스 적용됨
+        ]"
         @click.stop
       >
         <!-- 닫기 버튼 -->

--- a/src/components/common/ProductFilterModal.vue
+++ b/src/components/common/ProductFilterModal.vue
@@ -83,6 +83,7 @@ const availableVendors = computed(() =>
       title="상품 상세 조건 검색"
       icon="tune"
       @close="emit('close')"
+      size="max-w-5xl"
   >
     <form class="space-y-4">
 

--- a/src/router/asnRoutes.js
+++ b/src/router/asnRoutes.js
@@ -1,0 +1,11 @@
+import VendorAsnPage from '@/views/asn/VendorAsnPage.vue'
+
+const asnRoutes = [
+  {
+    path: '/asn/vendor',
+    name: 'vendorAsn',
+    component: VendorAsnPage,
+  },
+]
+
+export default asnRoutes

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -13,6 +13,7 @@ import vendorRoutes from '@/router/vendorRoutes.js'
 import franchiseRoutes from '@/router/franchiseRoutes.js'
 import announcementRoutes from './announcementRoutes'
 import warehouseRoutes from '@/router/warehouseRoutes.js'
+import asnRoutes from '@/router/asnRoutes.js'
 
 const routes = [
   {
@@ -36,6 +37,7 @@ const routes = [
   ...franchiseRoutes,
   ...announcementRoutes,
   ...warehouseRoutes,
+  ...asnRoutes,
 ]
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),

--- a/src/utils/statusMapper.js
+++ b/src/utils/statusMapper.js
@@ -1,15 +1,20 @@
 // 상태 매핑 테이블 (공통)
 export const STATUS_MAP = {
   // 발주
-  pending: { label: '보류 중', color: 'gray' },
-  approved: { label: '승인 완료', color: 'warning' },
-  shipped: { label: '배송 중', color: 'info' },
-  received: { label: '입고 완료', color: 'success' },
+  requested: { label: '발주 요청', color: 'info' }, // 승인 대기
+  approved: { label: '승인 완료', color: 'success' }, // 공급사로 발주 전송
+  awaiting_delivery: { label: '납품 대기', color: 'warning' }, // ASN 수신 후
+  completed: { label: '배송 완료', color: 'success' },
+  cancelled: { label: '취소됨', color: 'danger' },
 
   // 입고
-  draft: { label: '임시저장', color: 'gray' },
-  in_progress: { label: '입고 중', color: 'warning' },
-  completed: { label: '입고 완료', color: 'success' },
+  created: { label: '입고서 생성', color: 'gray' },
+  scheduled: { label: '입고 예정', color: 'info' },
+  arrived: { label: '도착', color: 'warning' },
+  inspecting: { label: '검수 중', color: 'warning' },
+  putaway: { label: '적치 중', color: 'info' },
+  completed_inbound: { label: '입고 완료', color: 'success' }, // 중복 구분용
+  cancelled_inbound: { label: '입고 취소', color: 'danger' },
 
   // 직원
   active: { label: '재직', color: 'success' },

--- a/src/views/asn/VendorAsnPage.vue
+++ b/src/views/asn/VendorAsnPage.vue
@@ -1,0 +1,223 @@
+<template>
+  <AppPageLayout>
+    <!-- 헤더 영역 -->
+    <template #header>
+      <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-3">
+        <div>
+          <h1 class="text-2xl font-semibold text-slate-900 dark:text-white">ASN 발송 (Vendor)</h1>
+          <p class="text-sm text-slate-500 dark:text-slate-400 mt-1">
+            외부 업체가 발주에 대한 ASN을 발송하거나 거절할 수 있습니다.
+          </p>
+        </div>
+
+        <div class="flex items-center gap-3">
+          <SearchBarComp
+            v-model="query"
+            placeholder="발주 코드 또는 업체명 검색"
+            @search="handleSearch"
+          />
+        </div>
+      </div>
+    </template>
+
+    <!-- ASN 목록 테이블 -->
+    <TableComp :columns="columns" :data="pagedOrders">
+      <template #cell-status="{ row }">
+        <BadgeComp :color="getStatusColor(row.status)" :label="getStatusLabel(row.status)" />
+      </template>
+
+      <template #actions="{ row }">
+        <div class="flex gap-2 justify-center">
+          <ButtonComp
+            color="primary"
+            class="px-4 py-1 text-xs font-semibold text-white rounded-md"
+            @click="openAsnModal(row, 'ACCEPTED')"
+          >
+            ASN 발송
+          </ButtonComp>
+          <ButtonComp
+            color="danger"
+            class="px-4 py-1 text-xs font-semibold text-white rounded-md"
+            @click="openAsnModal(row, 'REJECTED')"
+          >
+            거절
+          </ButtonComp>
+        </div>
+      </template>
+    </TableComp>
+
+    <!-- 페이지네이션 -->
+    <div class="flex justify-center items-center gap-2 mt-8">
+      <ButtonComp
+        color="secondary"
+        icon="arrow_back"
+        :disabled="page === 0"
+        @click="changePage(page - 1)"
+      >
+        이전
+      </ButtonComp>
+      <span class="text-sm text-slate-600 whitespace-nowrap">
+        페이지 {{ page + 1 }} / {{ totalPages }}
+      </span>
+      <ButtonComp
+        color="secondary"
+        icon="arrow_forward"
+        :disabled="page >= totalPages - 1"
+        @click="changePage(page + 1)"
+      >
+        다음
+      </ButtonComp>
+    </div>
+
+    <!-- ASN 발송/거절 모달 -->
+    <ModalComp
+      :open="asnModalOpen"
+      title="ASN 발송 확인"
+      icon="local_shipping"
+      @close="asnModalOpen = false"
+    >
+      <div class="p-6 text-center space-y-6">
+        <p class="text-gray-700 dark:text-gray-200">
+          발주서 <strong>{{ selectedOrder?.code }}</strong> 에 대해
+          <strong>{{ asnTypeLabel }}</strong> 하시겠습니까?
+        </p>
+        <div class="flex justify-end gap-3 pt-4 border-t border-gray-100 dark:border-gray-700">
+          <ButtonComp color="secondary" @click="asnModalOpen = false">취소</ButtonComp>
+          <ButtonComp color="primary" @click="submitAsn">확인</ButtonComp>
+        </div>
+      </div>
+    </ModalComp>
+  </AppPageLayout>
+</template>
+
+<script setup>
+import { computed, onMounted, ref } from 'vue'
+import AppPageLayout from '@/layouts/AppPageLayout.vue'
+import TableComp from '@/components/common/TableComp.vue'
+import ButtonComp from '@/components/common/ButtonComp.vue'
+import ModalComp from '@/components/common/ModalComp.vue'
+import BadgeComp from '@/components/common/BadgeComp.vue'
+import SearchBarComp from '@/components/common/SearchBarComp.vue'
+import api from '@/api/asn'
+
+// -------------------------
+// 상태 변수
+// -------------------------
+const purchaseOrders = ref([])
+const query = ref('')
+const page = ref(0)
+const pageSize = 10
+const asnModalOpen = ref(false)
+const selectedOrder = ref(null)
+const asnType = ref(null)
+
+// -------------------------
+// 테이블 컬럼 정의
+// -------------------------
+const columns = [
+  { key: 'code', label: '발주 코드' },
+  { key: 'vendorName', label: '업체명' },
+  { key: 'status', label: '상태' },
+  { key: 'createdAt', label: '등록일' },
+]
+
+// -------------------------
+// 페이지네이션
+// -------------------------
+const totalPages = computed(() => Math.ceil(purchaseOrders.value.length / pageSize))
+const pagedOrders = computed(() => {
+  const start = page.value * pageSize
+  return purchaseOrders.value.slice(start, start + pageSize)
+})
+const changePage = (newPage) => {
+  if (newPage < 0 || newPage >= totalPages.value) return
+  page.value = newPage
+}
+
+// -------------------------
+// 임시 데이터 (Mock)
+// -------------------------
+const mockPurchaseOrders = [
+  { id: 1, code: 'PO-2025102901', vendorName: '올리브영 납품업체 A', status: 'REQUESTED', createdAt: '2025-10-29' },
+  { id: 2, code: 'PO-2025102902', vendorName: '더페이스샵 공급업체 B', status: 'APPROVED', createdAt: '2025-10-28' },
+  { id: 3, code: 'PO-2025102903', vendorName: '토니모리 유통업체 C', status: 'REJECTED', createdAt: '2025-10-27' },
+]
+
+// -------------------------
+// 데이터 조회 (Mock)
+// -------------------------
+const fetchPurchaseOrders = async () => {
+  purchaseOrders.value = mockPurchaseOrders
+}
+
+// -------------------------
+// 검색
+// -------------------------
+const handleSearch = () => {
+  if (!query.value) {
+    purchaseOrders.value = mockPurchaseOrders
+    return
+  }
+
+  const q = query.value.toLowerCase()
+  purchaseOrders.value = mockPurchaseOrders.filter(
+    (item) =>
+      item.code.toLowerCase().includes(q) ||
+      item.vendorName.toLowerCase().includes(q)
+  )
+}
+
+// -------------------------
+// ASN 모달 제어
+// -------------------------
+const openAsnModal = (order, type) => {
+  selectedOrder.value = order
+  asnType.value = type
+  asnModalOpen.value = true
+}
+
+const asnTypeLabel = computed(() =>
+  asnType.value === 'ACCEPTED' ? 'ASN 발송(수락)' : '거절'
+)
+
+// -------------------------
+// ASN 전송
+// -------------------------
+const submitAsn = async () => {
+  if (!selectedOrder.value) return
+  const payload = {
+    purchaseOrderId: selectedOrder.value.id,
+    status: asnType.value,
+  }
+
+  if (asnType.value === 'ACCEPTED') {
+    await api.vendorAsnSend(payload)
+  } else {
+    await api.vendorAsnReject(payload)
+  }
+
+  asnModalOpen.value = false
+  alert(`ASN ${asnType.value === 'ACCEPTED' ? '발송' : '거절'} 완료!`)
+}
+
+// -------------------------
+const getStatusColor = (status) => {
+  switch (status) {
+    case 'REQUESTED': return 'info'
+    case 'APPROVED': return 'success'
+    case 'REJECTED': return 'danger'
+    default: return 'gray'
+  }
+}
+
+const getStatusLabel = (status) => {
+  switch (status) {
+    case 'REQUESTED': return '요청됨'
+    case 'APPROVED': return '승인됨'
+    case 'REJECTED': return '거절됨'
+    default: return '미정'
+  }
+}
+
+onMounted(fetchPurchaseOrders)
+</script>

--- a/src/views/franchise/FranchiseUpdate.vue
+++ b/src/views/franchise/FranchiseUpdate.vue
@@ -167,12 +167,16 @@ const fetchFranchise = async () => {
 // ✅ PATCH 수정 요청
 const updateFranchise = async () => {
   try {
-    const res = await franchiseApi.franchiseUpdate(form.value)
-    if (res.data?.success) {
+
+    const id = form.value.id
+    const payload = { ...form.value}
+
+    const res = await franchiseApi.franchiseUpdate(id, payload)
+    if (res?.success || res?.data?.success) {
       alert('가맹점 정보가 수정되었습니다.')
-      router.push({ name: 'franchiseDetail', params: { id: route.params.id } })
+      router.push({ name: 'franchiseDetail', params: { id } })
     } else {
-      alert('수정 실패: ' + (res.data?.message || '알 수 없는 오류'))
+      alert('수정 실패: ' + (res?.message || res?.data?.message || '알 수 없는 오류'))
     }
   } catch (err) {
     console.error('❌ 수정 실패:', err)

--- a/src/views/inbound/InboundList.vue
+++ b/src/views/inbound/InboundList.vue
@@ -179,13 +179,13 @@ const formatDate = (dateStr) => {
 const getStatusColor = (status) => {
   switch (status) {
     case 'SCHEDULED':
-      return 'blue'
+      return 'info'
     case 'INSPECTING':
-      return 'yellow'
+      return 'warning'
     case 'COMPLETED':
-      return 'green'
+      return 'success'
     case 'CANCELLED':
-      return 'red'
+      return 'danger'
     default:
       return 'gray'
   }

--- a/src/views/vendor/VendorList.vue
+++ b/src/views/vendor/VendorList.vue
@@ -8,6 +8,8 @@
     </template>
 
     <!-- 검색창 -->
+    <section class="bg-zinc-50 dark:bg-zinc-900/40 border border-zinc-200 dark:border-zinc-700
+         rounded-xl shadow-sm p-6 md:p-8 space-y-6">
     <SearchBarComp v-model="searchText" placeholder="공급업체명 / 코드 검색" />
 
     <!-- 테이블 -->
@@ -25,6 +27,7 @@
         />
       </template>
     </TableComp>
+    </section>
   </AppPageLayout>
 </template>
 


### PR DESCRIPTION
# 🧩 Issue
* #78 

## 📝 요약
> PR의 목적이나 변경 내용을 간단히 요약
feat:asn페이지 구현 초안

## 🔍 변경 사항
VendorAsnPage 기초 구현
FranchiseUpdate.vue에서 updateFranchise patch 수정 데이터 불러올 수 있게 해두었습니다.
statusMapper 발주/입고 컬럼명 백엔드에 status랑 맵핑해뒀습니다.
상품 상세 조회 모달창 size 늘려뒀습니다.
* #78 

## ✅ 체크리스트
- [x] 코드 컨벤션을 준수 했는가?
- [x] 커밋 내용에 시크릿 키 등의 공유되지 말아야 할 것들을 제거 했는가?

## 💬 기타 공유사항
VendorAsnPage페이지의 경우 벤더에서 승인/거부한 내역들 목록으로 불러오는 페이지 구현하도록 하겠습니다(10/30)
( 벤더에서 승인/거부는 postman으로 진행)