### PR TITLE
feat:권한별로 들어갈수 있는 페이지 설정 & 생성 수정 같은 버튼은 관리자만 보이는 기능 추가

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,71 +1,41 @@
 <template>
   <div class="flex flex-col min-h-screen bg-background-light dark:bg-background-dark">
-    <AppHeader/>
-    <!-- Main (Sidebar + Contents) -->
+    <!-- 헤더 -->
+    <AppHeader v-if="!isLoginPage" />
+
     <div class="flex flex-1 min-h-0">
-      <AppSidebar/>
+      <AppSidebar v-if="!isLoginPage" />
+
       <RouterView v-slot="{ Component, route }" class="flex-1 overflow-y-auto">
-        <transition
-          mode="out-in"
-          enter-active-class="transition-opacity duration-200"
-          enter-from-class="opacity-0"
-          leave-active-class="transition-opacity duration-200"
-          leave-to-class="opacity-0"
-        >
-          <!-- page fade 기능 구현 -->
-          <component :is="Component" :key="route.fullPath"/>
+        <transition mode="out-in" enter-active-class="transition-opacity duration-200" enter-from-class="opacity-0"
+          leave-active-class="transition-opacity duration-200" leave-to-class="opacity-0">
+          <component :is="Component" :key="route.fullPath" />
         </transition>
       </RouterView>
     </div>
   </div>
-  <AppFooter/>
 
-  <!-- 로그인 모달창 -->
-  <LoginModal v-if="ui.isLoginModalOpen"/>
-
-  <!-- 알림 모달 -->
-  <ModalComp
-    :open="ui.isNotificationModalOpen"
-    :title="ui.notificationModalTitle"
-    :icon="ui.notificationModalIcon"
-    @close="handleConfirm"
-  >
-    <p>{{ ui.notificationModalMessage }}</p>
-    <template #footer>
-      <div class="flex justify-end">
-        <button
-          @click="handleConfirm"
-          class="px-4 py-2 bg-primary text-white rounded-md"
-        >
-          확인
-        </button>
-      </div>
-    </template>
-  </ModalComp>
+  <!-- 푸터 -->
+  <AppFooter v-if="!isLoginPage" />
 </template>
 
 <script setup>
+import { computed, onMounted } from 'vue'
+import { useRoute } from 'vue-router'
+
 import AppHeader from '@/components/common/AppHeader.vue'
 import AppSidebar from '@/components/common/AppSideBar.vue'
 import AppFooter from '@/components/common/AppFooter.vue'
-import LoginModal from '@/components/auth/LoginModal.vue'
-import ModalComp from '@/components/common/ModalComp.vue' // 추가
-import {useUIStore} from '@/stores/uiStore.js'
-import {useVendorStore} from "@/stores/vendorStore.js";
-import {onMounted} from "vue";
 
-const vendorStore = useVendorStore();
+import { useVendorStore } from '@/stores/vendorStore.js'
+
+const vendorStore = useVendorStore()
+const route = useRoute()
 
 onMounted(() => {
   vendorStore.fetchVendors()
 })
 
-const ui = useUIStore()
-
-const handleConfirm = () => {
-  if (ui.notificationModalOnConfirm) {
-    ui.notificationModalOnConfirm()
-  }
-  ui.closeNotificationModal()
-}
+// 로그인 페이지에서는 전역 레이아웃 숨김
+const isLoginPage = computed(() => route.path === '/auth/login')
 </script>

--- a/src/api/member/index.js
+++ b/src/api/member/index.js
@@ -2,7 +2,7 @@ import api from '@/plugin/axiosInterceptor.js'
 
 const memberLogin = async (req) => {
   let data = {}
-  let url = '/api/login'
+  let url = '/login'
 
   await api
     .post(url, req)
@@ -18,7 +18,7 @@ const memberLogin = async (req) => {
 
 const memberLogout = async (req) => {
   let data = {}
-  let url = '/api/logout'
+  let url = '/logout'
 
   await api
     .post(url, req)

--- a/src/router/announcementRoutes.js
+++ b/src/router/announcementRoutes.js
@@ -8,21 +8,25 @@ const announcementRoutes = [
     path: '/announcement',
     name: '공지사항',
     component: Announcemnet,
+    meta: { roles: ['MANAGER'] },
   },
   {
     path: '/announcement/create',
     name: '공지사항 생성',
     component: AnnouncementCreate,
+    meta: { roles: ['MANAGER'] },
   },
   {
     path: '/announcement/:id',
     name: 'announcementDetail',
     component: AnnouncementDetail,
+    meta: { roles: ['MANAGER'] },
   },
   {
     path: '/announcement/edit/:id',
     name: 'AnnouncementEdit',
     component: AnnouncementEdit,
+    meta: { roles: ['MANAGER'] },
   },
 ]
 

--- a/src/router/dashboardRoutes.js
+++ b/src/router/dashboardRoutes.js
@@ -5,6 +5,7 @@ const dashboardRoutes = [
     path: '/dashboard',
     name: 'Dashboard',
     component: DashBoardMain,
+    meta: { roles: ['ADMIN', 'MANAGER'] },
   },
 ]
 

--- a/src/router/employeeRoutes.js
+++ b/src/router/employeeRoutes.js
@@ -7,16 +7,19 @@ const employeeRoutes = [
     path: '/employee',
     name: 'employee',
     component: EmployeeManegment,
+    meta: { roles: ['MANAGER'] },
   },
   {
     path: '/employee/create',
     name: 'employeeCreate',
     component: EmployeeCreate,
+    meta: { roles: ['MANAGER'] },
   },
   {
     path: '/employee/:id',
     name: 'employeeId',
     component: EmployeeDetail,
+    meta: { roles: ['MANAGER'] },
   },
 ]
 

--- a/src/router/franchiseRoutes.js
+++ b/src/router/franchiseRoutes.js
@@ -8,21 +8,25 @@ const franchiseRoutes = [
         path: '/franchise',
         name: 'franchiseList',
         component: FranchiseList,
+        meta: { roles: ['MANAGER'] },
     },
     {
         path: '/franchise/create',
         name: 'franchiseCreate',
         component: FranchiseCreate,
+        meta: { roles: ['MANAGER'] },
     },
     {
         path: '/franchise/:id',
         name: 'franchiseDetail',
         component: FranchiseDetail,
+        meta: { roles: ['MANAGER'] },
     },
     {
         path: '/franchise/edit/:id',
         name: 'franchiseUpdate',
         component: FranchiseUpdate,
+        meta: { roles: ['MANAGER'] },
     },
 ]
 

--- a/src/router/inboundRoutes.js
+++ b/src/router/inboundRoutes.js
@@ -7,17 +7,20 @@ const inboundRoutes = [
     path: '/inbound',
     name: 'inboundList',
     component: InboundList,
+    meta: { roles: ['MANAGER'] },
   },
   {
     path: '/inbound/create',
     name: 'inboundCreate',
     component: InboundCreate,
+    meta: { roles: ['MANAGER'] },
   },
   {
     path: '/inbound/:id',
     name: 'inboundDetail',
     component: InboundDetail,
     props: true,
+    meta: { roles: ['MANAGER'] },
   },
 ]
 

--- a/src/router/inventoryRoutes.js
+++ b/src/router/inventoryRoutes.js
@@ -6,11 +6,13 @@ const inventoryRoutes = [
         path: '/inventory',
         name: 'inventoryList',
         component: InventoryList,
+        meta: { roles: ['MANAGER'] },
     },
     {
         path: '/inventory/detail/:productCode',
         name: 'inventoryDetail',
         component: InventoryDetail,
+        meta: { roles: ['MANAGER'] },
     },
 ]
 

--- a/src/router/outboundRoutes.js
+++ b/src/router/outboundRoutes.js
@@ -7,16 +7,19 @@ export default [
     path: '/outbound',
     name: 'OutboundList',
     component: OutboundList,
+    meta: { roles: ['MANAGER'] },
   },
   {
     path: '/outbound/create',
     name: 'OutboundCreate',
     component: OutboundCreate,
+    meta: { roles: ['MANAGER'] },
   },
   {
     path: '/outbound/:id',
     name: 'OutboundDetail',
     component: OutboundDetail,
     props: true, // id를 props로 전달 (inbound 구조 동일)
+    meta: { roles: ['MANAGER'] },
   },
 ]

--- a/src/router/productRoutes.js
+++ b/src/router/productRoutes.js
@@ -7,15 +7,18 @@ export default [
     path: '/product',
     name: 'ProductList',
     component: ProductList,
+    meta: { roles: ['MANAGER'] },
   },
   {
     path: '/product/register',
     name: 'ProductRegister',
     component: ProductRegister,
+    meta: { roles: ['MANAGER'] },
   },
   {
     path: '/product/:id',
     name: 'ProductDetail',
     component: ProductDetail,
+    meta: { roles: ['MANAGER'] },
   },
 ]

--- a/src/router/purchaseOrderRoutes.js
+++ b/src/router/purchaseOrderRoutes.js
@@ -7,16 +7,19 @@ const purchaseOrderRoutes = [
     path: '/purchase',
     name: 'purchaseOrder',
     component: PurchaseOrderList,
+    meta: { roles: ['MANAGER'] },
   },
   {
     path: '/purchase/create',
     name: 'purchaseOrderCreate',
     component: PurchaseOrderCreate,
+    meta: { roles: ['MANAGER'] },
   },
   {
     path: '/purchase/:id',
     name: 'purchaseOrderDetail',
     component: PurchaseOrderDetail,
+    meta: { roles: ['MANAGER'] },
   },
 ]
 

--- a/src/router/taskRoutes.js
+++ b/src/router/taskRoutes.js
@@ -3,20 +3,24 @@ export default [
     path: '/task/list',
     name: 'TaskList',
     component: () => import('@/views/task/TaskList.vue'),
+    meta: { roles: ['MANAGER', 'WORKER'] },
   },
   {
     path: '/task/detail/:id',
     name: 'TaskDetail',
     component: () => import('@/views/task/TaskDetail.vue'),
+    meta: { roles: ['MANAGER', 'WORKER'] },
   },
   {
     path: '/task/Worker/view',
     name: 'TaskWorkerView',
     component: () => import('@/views/task/WorkerTaskView.vue'),
+    meta: { roles: ['MANAGER', 'WORKER'] },
   },
   {
     path: '/task/Kanban',
     name: 'TaskKanban',
     component: () => import('@/views/task/TaskKanban.vue'),
+    meta: { roles: ['MANAGER', 'WORKER'] },
   },
 ]

--- a/src/router/vendorRoutes.js
+++ b/src/router/vendorRoutes.js
@@ -7,17 +7,20 @@ const vendorRoutes = [
     path: '/vendors',
     name: 'vendorList',
     component: vendorList,
+    meta: { roles: ['MANAGER'] },
   },
   {
     path: '/vendors/create',
     name: 'vendorCreate',
     component: vendorCreate,
+    meta: { roles: ['MANAGER'] },
   },
   {
     path: '/vendors/:id',
     name: 'vendorDetail',
     component: vendorDetail,
     props: true,
+    meta: { roles: ['MANAGER'] },
   },
 ]
 

--- a/src/router/warehouseRoutes.js
+++ b/src/router/warehouseRoutes.js
@@ -7,21 +7,25 @@ const warehouseRoutes = [
         path: '/warehouse',
         name: 'warehouseList',
         component: WarehouseList,
+        meta: { roles: ['MANAGER'] },
     },
     {
         path: '/warehouse/create',
         name: 'warehouseCreate',
         component: WarehouseCreate,
+        meta: { roles: ['MANAGER'] },
     },
     {
         path: '/warehouse/:id',
         name: 'warehouseDetail',
         component: WarehouseDetail,
+        meta: { roles: ['MANAGER'] },
     },
     {
         path: '/warehouse/update/:id',
         name: 'warehouseUpdate',
         component: WarehouseDetail,
+        meta: { roles: ['MANAGER'] },
     },
 ]
 

--- a/src/stores/authStore.js
+++ b/src/stores/authStore.js
@@ -4,20 +4,32 @@ import MemberApi from '@/api/member/index.js'
 export const useAuthStore = defineStore('auth', {
   state: () => ({
     isAuthenticated: localStorage.getItem('isAuthenticated') === 'true',
+    role: localStorage.getItem('userRole') || null,
   }),
+
+  getters: {
+    // 관리자 여부 간단히 확인 가능
+    isAdmin: (state) => state.role === 'ADMIN',
+  },
+
   actions: {
-    login() {
+    login(role) {
       this.isAuthenticated = true
+      this.role = role
       localStorage.setItem('isAuthenticated', 'true')
+      localStorage.setItem('userRole', role)
     },
+
     async logout() {
       try {
         await MemberApi.memberLogout({})
-        this.isAuthenticated = false
-        localStorage.removeItem('isAuthenticated')
-        // 라우터 이동은 logout을 호출하는 컴포넌트에서 처리
       } catch (error) {
         console.error('Logout failed:', error)
+      } finally {
+        this.isAuthenticated = false
+        this.role = null
+        localStorage.removeItem('isAuthenticated')
+        localStorage.removeItem('userRole')
       }
     },
   },

--- a/src/stores/uiStore.js
+++ b/src/stores/uiStore.js
@@ -3,11 +3,6 @@ import { defineStore } from 'pinia'
 export const useUIStore = defineStore('ui', {
     state: () => ({
         isLoginModalOpen: false,
-        isNotificationModalOpen: false,
-        notificationModalTitle: '',
-        notificationModalMessage: '',
-        notificationModalOnConfirm: null,
-        notificationModalIcon: '', // 아이콘 추가
     }),
     actions: {
         openLoginModal() {
@@ -15,20 +10,6 @@ export const useUIStore = defineStore('ui', {
         },
         closeLoginModal() {
             this.isLoginModalOpen = false
-        },
-        openNotificationModal({ title, message, onConfirm, icon = '' }) {
-            this.notificationModalTitle = title
-            this.notificationModalMessage = message
-            this.notificationModalOnConfirm = onConfirm
-            this.notificationModalIcon = icon
-            this.isNotificationModalOpen = true
-        },
-        closeNotificationModal() {
-            this.isNotificationModalOpen = false
-            this.notificationModalTitle = ''
-            this.notificationModalMessage = ''
-            this.notificationModalOnConfirm = null
-            this.notificationModalIcon = ''
         },
     },
 })

--- a/src/views/announcement/AnnouncementDetail.vue
+++ b/src/views/announcement/AnnouncementDetail.vue
@@ -8,8 +8,8 @@
                 </div>
                 <div class="flex gap-2">
                     <ButtonComp color="secondary" @click="$router.back()">뒤로가기</ButtonComp>
-                    <ButtonComp color="primary" @click="goToEdit">수정</ButtonComp>
-                    <ButtonComp color="danger" @click="openDeleteModal">삭제</ButtonComp>
+                    <ButtonComp v-if="auth.isAdmin" color="primary" @click="goToEdit">수정</ButtonComp>
+                    <ButtonComp v-if="auth.isAdmin" color="danger" @click="openDeleteModal">삭제</ButtonComp>
                 </div>
             </div>
         </template>
@@ -101,6 +101,7 @@ import ModalComp from '@/components/common/ModalComp.vue'
 import { useRouter, useRoute } from 'vue-router'
 import announcementApi from '@/api/announcement/index.js'
 import { formatDate } from '@/utils/date.js'
+import { useAuthStore } from '@/stores/authStore'
 
 const router = useRouter()
 const route = useRoute()
@@ -109,6 +110,7 @@ const announcement = ref(null)
 const announcementList = ref([])
 const loading = ref(true)
 const error = ref(null)
+const auth = useAuthStore()
 
 // ✅ 모달 상태
 const showDeleteModal = ref(false)

--- a/src/views/announcement/Announcemnet.vue
+++ b/src/views/announcement/Announcemnet.vue
@@ -10,7 +10,7 @@
                     </p>
                 </div>
                 <div class="flex items-center gap-2">
-                    <ButtonComp color="primary" icon="add" @click="goCreate">신규 공지</ButtonComp>
+                    <ButtonComp v-if="auth.isAdmin" color="primary" icon="add" @click="goCreate">신규 공지</ButtonComp>
                 </div>
             </div>
         </template>
@@ -75,6 +75,7 @@ import SearchBarComp from '@/components/common/SearchBarComp.vue'
 import TableComp from '@/components/common/TableComp.vue'
 import announcementApi from '@/api/announcement/index.js'
 import { formatDate } from '@/utils/date.js'
+import { useAuthStore } from '@/stores/authStore'
 
 const router = useRouter()
 const searchQuery = ref('')
@@ -82,6 +83,7 @@ const page = ref(0)
 const size = ref(10)
 const totalPages = ref(1)
 const announcementList = ref([])
+const auth = useAuthStore()
 
 const filters = ref({
     startDate: '',

--- a/src/views/employee/EmployeeDetail.vue
+++ b/src/views/employee/EmployeeDetail.vue
@@ -94,7 +94,7 @@
 
             <!-- 버튼 영역 -->
             <div class="mt-8 flex justify-end gap-3">
-                <ButtonComp v-if="!isEditMode" color="primary" icon="edit" @click="toggleEditMode">
+                <ButtonComp v-if="!isEditMode && auth.isAdmin" color="primary" icon="edit" @click="toggleEditMode">
                     수정
                 </ButtonComp>
                 <ButtonComp v-if="isEditMode" color="primary" icon="save" @click="saveEmployee">
@@ -117,10 +117,11 @@ import { useRoute, useRouter } from 'vue-router'
 import member from '@/api/member'
 import { getStatusLabel, getStatusColor } from '@/utils/statusMapper.js'
 import { formatDate } from '@/utils/date.js'
+import { useAuthStore } from '@/stores/authStore'
 
 const route = useRoute()
 const router = useRouter()
-
+const auth = useAuthStore()
 const employee = ref({})
 const editableEmployee = ref({})
 const isEditMode = ref(false)

--- a/src/views/employee/EmployeeManegment.vue
+++ b/src/views/employee/EmployeeManegment.vue
@@ -13,7 +13,7 @@
                 <div class="flex items-center gap-3">
                     <!-- 신규 직원 등록 -->
                     <RouterLink to="/employee/create" class="w-40">
-                        <ButtonComp color="primary" icon="add">직원 등록</ButtonComp>
+                        <ButtonComp v-if="auth.isAdmin" color="primary" icon="add">직원 등록</ButtonComp>
                     </RouterLink>
                 </div>
             </div>
@@ -128,8 +128,10 @@ import BadgeComp from '@/components/common/BadgeComp.vue'
 import SearchBarComp from '@/components/common/SearchBarComp.vue'
 import TableComp from '@/components/common/TableComp.vue'
 import { getStatusLabel, getStatusColor } from '@/utils/statusMapper.js'
+import { useAuthStore } from '@/stores/authStore'
 
 const router = useRouter()
+const auth = useAuthStore()
 
 // 🔍 검색 조건
 const searchParams = ref({

--- a/src/views/franchise/FranchiseDetail.vue
+++ b/src/views/franchise/FranchiseDetail.vue
@@ -15,7 +15,7 @@
           <ButtonComp color="secondary" icon="arrow_back" @click="$router.push({ name: 'franchiseList' })">
             뒤로가기
           </ButtonComp>
-          <ButtonComp color="primary" icon="edit" @click="editFranchise">
+          <ButtonComp v-if="auth.isAdmin" color="primary" icon="edit" @click="editFranchise">
             수정
           </ButtonComp>
           <!--          <ButtonComp color="danger" icon="block" @click="suspendFranchise">-->
@@ -27,10 +27,8 @@
 
     <section v-if="franchise" class="space-y-8">
       <!-- 기본 정보 -->
-      <div
-          class="bg-zinc-50 dark:bg-zinc-900/40 border border-zinc-200 dark:border-zinc-700
-               rounded-xl shadow-sm p-6 backdrop-blur-sm"
-      >
+      <div class="bg-zinc-50 dark:bg-zinc-900/40 border border-zinc-200 dark:border-zinc-700
+               rounded-xl shadow-sm p-6 backdrop-blur-sm">
         <h2 class="text-lg font-semibold mb-4 text-slate-900 dark:text-white">기본 정보</h2>
 
         <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-x-8 gap-y-4">
@@ -49,10 +47,8 @@
       </div>
 
       <!-- 주소 정보 -->
-      <div
-          class="bg-zinc-50 dark:bg-zinc-900/40 border border-zinc-200 dark:border-zinc-700
-               rounded-xl shadow-sm p-6 backdrop-blur-sm"
-      >
+      <div class="bg-zinc-50 dark:bg-zinc-900/40 border border-zinc-200 dark:border-zinc-700
+               rounded-xl shadow-sm p-6 backdrop-blur-sm">
         <h2 class="text-lg font-semibold mb-4 text-slate-900 dark:text-white">주소 정보</h2>
         <div class="space-y-2">
           <div><span class="text-gray-500 text-sm block">우편번호</span> {{ franchise.address?.zipcode || '-' }}</div>
@@ -71,15 +67,17 @@
 </template>
 
 <script setup>
-import {onMounted, ref} from 'vue'
-import {useRoute, useRouter} from 'vue-router'
+import { onMounted, ref } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
 import AppPageLayout from '@/layouts/AppPageLayout.vue'
 import ButtonComp from '@/components/common/ButtonComp.vue'
 import franchiseApi from "@/api/franchise/index.js";
+import { useAuthStore } from '@/stores/authStore';
 
 const route = useRoute()
 const router = useRouter()
 const franchise = ref(null)
+const auth = useAuthStore()
 
 // ✅ 가맹점 상세 조회
 const getFranchises = async () => {
@@ -100,7 +98,7 @@ const getFranchises = async () => {
 
 // ✅ 수정 이동 (name 기반)
 const editFranchise = () => {
-  router.push({name: 'franchiseUpdate', params: {id: route.params.id}})
+  router.push({ name: 'franchiseUpdate', params: { id: route.params.id } })
 }
 
 // ✅ 날짜 포맷

--- a/src/views/franchise/FranchiseList.vue
+++ b/src/views/franchise/FranchiseList.vue
@@ -13,15 +13,11 @@
         <div class="flex items-center gap-3">
           <!-- 신규 가맹점 등록 -->
           <RouterLink to="/franchise/create" class="w-40">
-            <ButtonComp color="primary" icon="add" class="whitespace-nowrap">신규 가맹점</ButtonComp>
+            <ButtonComp v-if="auth.isAdmin" color="primary" icon="add" class="whitespace-nowrap">신규 가맹점</ButtonComp>
           </RouterLink>
 
           <!-- 검색창 -->
-          <SearchBarComp
-              v-model="query"
-              placeholder="가맹점명 또는 코드 검색..."
-              @search="handleSearch"
-          />
+          <SearchBarComp v-model="query" placeholder="가맹점명 또는 코드 검색..." @search="handleSearch" />
         </div>
       </div>
     </template>
@@ -30,17 +26,15 @@
     <TableComp :columns="columns" :data="filteredFranchises">
       <!-- 가맹점코드 -->
       <template #cell-franchiseCode="{ row }">
-        <RouterLink
-            :to="{ name: 'franchiseDetail', params: { id: row.id } }"
-            class="text-blue-600 dark:text-blue-400 hover:underline font-medium"
-        >
+        <RouterLink :to="{ name: 'franchiseDetail', params: { id: row.id } }"
+          class="text-blue-600 dark:text-blue-400 hover:underline font-medium">
           {{ row.franchiseCode }}
         </RouterLink>
       </template>
 
       <!-- 상태 -->
       <template #cell-status="{ row }">
-        <BadgeComp :color="getStatusColor(row.status)" :label="getStatusLabel(row.status)"/>
+        <BadgeComp :color="getStatusColor(row.status)" :label="getStatusLabel(row.status)" />
       </template>
 
       <!-- 주소 -->
@@ -57,13 +51,14 @@
 </template>
 
 <script setup>
-import {computed, onMounted, ref} from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import franchiseApi from "@/api/franchise/index.js";
 import AppPageLayout from '@/layouts/AppPageLayout.vue'
 import SearchBarComp from '@/components/common/SearchBarComp.vue'
 import TableComp from '@/components/common/TableComp.vue'
 import ButtonComp from '@/components/common/ButtonComp.vue'
 import BadgeComp from '@/components/common/BadgeComp.vue'
+import { useAuthStore } from '@/stores/authStore'
 
 // 상태 표시 유틸
 const getStatusLabel = (status) => {
@@ -96,16 +91,17 @@ const formatDate = (dateStr) => {
 
 const franchises = ref([])
 const query = ref('')
+const auth = useAuthStore()
 
 // ✅ 테이블 컬럼 정의
 const columns = [
-  {key: 'franchiseCode', label: '가맹점 코드', width: '12%'},
-  {key: 'name', label: '가맹점명'},
-  {key: 'phoneNumber', label: '연락처'},
-  {key: 'email', label: '이메일'},
-  {key: 'address', label: '주소'}, // street만 표시
-  {key: 'status', label: '상태', align: 'center'},
-  {key: 'createdAt', label: '등록일'},
+  { key: 'franchiseCode', label: '가맹점 코드', width: '12%' },
+  { key: 'name', label: '가맹점명' },
+  { key: 'phoneNumber', label: '연락처' },
+  { key: 'email', label: '이메일' },
+  { key: 'address', label: '주소' }, // street만 표시
+  { key: 'status', label: '상태', align: 'center' },
+  { key: 'createdAt', label: '등록일' },
 ]
 
 // import 사용해서 불러오는 방식! 기억을 상기시켜 보시기 바람니다!
@@ -123,7 +119,7 @@ const filteredFranchises = computed(() => {
   const q = query.value.trim().toLowerCase()
   if (!q) return franchises.value
   return franchises.value.filter((f) =>
-      [f.franchiseCode, f.name, f.email].some((field) => field?.toLowerCase().includes(q))
+    [f.franchiseCode, f.name, f.email].some((field) => field?.toLowerCase().includes(q))
   )
 })
 

--- a/src/views/login/Login.vue
+++ b/src/views/login/Login.vue
@@ -1,10 +1,6 @@
 <template>
     <AppPageLayout>
-        <template #header>
-            <h1 class="text-2xl font-semibold text-slate-900 dark:text-white">로그인</h1>
-        </template>
-
-        <div class="flex flex-col items-center justify-center min-h-[70vh]">
+        <div class="flex flex-col items-center justify-center min-h-screen">
             <div class="w-full max-w-md bg-white dark:bg-slate-800 p-8 rounded-2xl shadow-lg text-center">
                 <div class="text-center mb-6">
                     <div
@@ -85,7 +81,7 @@ const onLogin = async () => {
         const res = await MemberApi.memberLogin(req)
 
         if (res.status === 20000 || res.message === '요청에 성공하였습니다.') {
-            auth.login()
+            auth.login(res.results.role)
             const role = res.results.role
             if (role === 'WORKER') {
                 router.push('/task/Worker/view')

--- a/src/views/product/ProductList.vue
+++ b/src/views/product/ProductList.vue
@@ -11,7 +11,7 @@
         </div>
         <div class="flex items-center gap-2">
           <ButtonComp color="secondary" icon="refresh" @click="resetFilters">초기화</ButtonComp>
-          <ButtonComp color="primary" icon="add" @click="goRegister">상품 등록</ButtonComp>
+          <ButtonComp v-if="auth.isAdmin" color="primary" icon="add" @click="goRegister">상품 등록</ButtonComp>
         </div>
       </div>
     </template>
@@ -101,9 +101,11 @@ import ButtonComp from '@/components/common/ButtonComp.vue'
 import SearchBarComp from '@/components/common/SearchBarComp.vue'
 import TableComp from '@/components/common/TableComp.vue'
 import ProductApi from '@/api/product/index.js'
+import { useAuthStore } from '@/stores/authStore'
 
 const router = useRouter()
 const vendorStore = useVendorStore() // ✅ Pinia 스토어 사용
+const auth = useAuthStore()
 const searchQuery = ref('')
 const page = ref(0)
 const size = ref(10)

--- a/src/views/vendor/VendorDetail.vue
+++ b/src/views/vendor/VendorDetail.vue
@@ -6,24 +6,15 @@
         <h1 class="text-2xl font-semibold text-slate-900 dark:text-white">공급업체 상세</h1>
 
         <div class="flex flex-wrap items-center gap-2 md:gap-3">
-          <ButtonComp color="primary" icon="edit" @click="openEditModal">수정</ButtonComp>
+          <ButtonComp v-if="auth.isAdmin" color="primary" icon="edit" @click="openEditModal">수정</ButtonComp>
 
           <!-- 상태별 버튼 분기 -->
-          <ButtonComp
-            v-if="vendor.status === 'ACTIVE'"
-            color="danger"
-            icon="block"
-            @click="updateStatus('SUSPENDED')"
-          >
+          <ButtonComp v-if="vendor.status === 'ACTIVE'" color="danger" icon="block" @click="updateStatus('SUSPENDED')">
             거래 중단
           </ButtonComp>
 
-          <ButtonComp
-            v-else-if="vendor.status === 'SUSPENDED'"
-            color="success"
-            icon="check_circle"
-            @click="updateStatus('ACTIVE')"
-          >
+          <ButtonComp v-else-if="vendor.status === 'SUSPENDED'" color="success" icon="check_circle"
+            @click="updateStatus('ACTIVE')">
             거래 활성화
           </ButtonComp>
 
@@ -35,11 +26,8 @@
     </template>
 
     <!-- 기본 정보 -->
-    <section
-      v-if="vendor.id"
-      class="bg-zinc-50 dark:bg-zinc-900/40 border border-zinc-200 dark:border-zinc-700
-             rounded-xl shadow-sm p-6 backdrop-blur-sm space-y-6"
-    >
+    <section v-if="vendor.id" class="bg-zinc-50 dark:bg-zinc-900/40 border border-zinc-200 dark:border-zinc-700
+             rounded-xl shadow-sm p-6 backdrop-blur-sm space-y-6">
       <h2 class="text-lg font-semibold text-slate-900 dark:text-white">기본 정보</h2>
 
       <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
@@ -67,8 +55,7 @@
           <span class="text-xs text-gray-500 block mb-1">상태</span>
           <BadgeComp
             :color="vendor.status === 'ACTIVE' ? 'success' : vendor.status === 'INACTIVE' ? 'warning' : 'danger'"
-            :label="getStatusLabel(vendor.status)"
-          />
+            :label="getStatusLabel(vendor.status)" />
         </div>
 
         <div class="lg:col-span-3">
@@ -89,11 +76,8 @@
     </section>
 
     <!-- 주소 정보 -->
-    <section
-      v-if="vendor.id"
-      class="bg-zinc-50 dark:bg-zinc-900/40 border border-zinc-200 dark:border-zinc-700
-             rounded-xl shadow-sm p-6 backdrop-blur-sm space-y-6"
-    >
+    <section v-if="vendor.id" class="bg-zinc-50 dark:bg-zinc-900/40 border border-zinc-200 dark:border-zinc-700
+             rounded-xl shadow-sm p-6 backdrop-blur-sm space-y-6">
       <h2 class="text-lg font-semibold text-slate-900 dark:text-white">주소 정보</h2>
 
       <div class="grid grid-cols-1 md:grid-cols-2 gap-5">
@@ -120,12 +104,7 @@
     </section>
 
     <!-- 수정 모달 -->
-    <ModalComp
-      :open="isEditModal"
-      title="공급업체 정보 수정"
-      icon="edit"
-      @close="isEditModal = false"
-    >
+    <ModalComp :open="isEditModal" title="공급업체 정보 수정" icon="edit" @close="isEditModal = false">
       <div class="space-y-4">
         <label class="flex flex-col gap-1.5">
           <span class="text-xs font-medium text-slate-700 dark:text-slate-200">공급업체명</span>
@@ -187,12 +166,14 @@ import AppPageLayout from '@/layouts/AppPageLayout.vue'
 import ButtonComp from '@/components/common/ButtonComp.vue'
 import BadgeComp from '@/components/common/BadgeComp.vue'
 import ModalComp from '@/components/common/ModalComp.vue'
+import { useAuthStore } from '@/stores/authStore'
 
 const route = useRoute()
 const router = useRouter()
 const vendor = ref({})
 const isEditModal = ref(false)
 const editForm = ref({})
+const auth = useAuthStore()
 
 // 상태 라벨 매핑
 const getStatusLabel = (status) => {

--- a/src/views/vendor/VendorList.vue
+++ b/src/views/vendor/VendorList.vue
@@ -3,14 +3,13 @@
     <template #header>
       <div class="flex justify-between items-center mb-4">
         <h1 class="text-2xl font-semibold text-slate-900 dark:text-white">공급업체 목록</h1>
-        <ButtonComp color="primary" icon="add" @click="goCreate">신규 등록</ButtonComp>
+        <ButtonComp v-if="auth.isAdmin" color="primary" icon="add" @click="goCreate">신규 등록</ButtonComp>
       </div>
     </template>
 
     <!-- 검색창 -->
     <section
-      class="bg-zinc-50 dark:bg-zinc-900/40 border border-zinc-200 dark:border-zinc-700 rounded-xl shadow-sm p-6 md:p-8 space-y-6"
-    >
+      class="bg-zinc-50 dark:bg-zinc-900/40 border border-zinc-200 dark:border-zinc-700 rounded-xl shadow-sm p-6 md:p-8 space-y-6">
       <SearchBarComp v-model="searchText" placeholder="공급업체명 / 코드 검색" />
 
       <!-- 테이블 -->
@@ -22,10 +21,8 @@
         </template>
 
         <template #cell-status="{ row }">
-          <BadgeComp
-            :color="row.status === 'ACTIVE' ? 'success' : 'danger'"
-            :label="row.status === 'ACTIVE' ? '거래중' : '중단'"
-          />
+          <BadgeComp :color="row.status === 'ACTIVE' ? 'success' : 'danger'"
+            :label="row.status === 'ACTIVE' ? '거래중' : '중단'" />
         </template>
       </TableComp>
     </section>
@@ -44,6 +41,7 @@ import ButtonComp from '@/components/common/ButtonComp.vue'
 import TableComp from '@/components/common/TableComp.vue'
 import SearchBarComp from '@/components/common/SearchBarComp.vue'
 import BadgeComp from '@/components/common/BadgeComp.vue'
+import { useAuthStore } from '@/stores/authStore'
 
 const router = useRouter()
 const goCreate = () => router.push('/vendors/create')
@@ -53,6 +51,7 @@ const { vendorList } = storeToRefs(vendorStore)
 
 const searchText = ref('')
 const searchResult = ref([])
+const auth = useAuthStore()
 
 const columns = [
   { key: 'vendorCode', label: '공급업체 코드' },

--- a/src/views/warehouse/WarehouseDetail.vue
+++ b/src/views/warehouse/WarehouseDetail.vue
@@ -16,7 +16,7 @@
           <ButtonComp color="secondary" icon="arrow_back" @click="$router.push({ name: 'warehouseList' })">
             뒤로가기
           </ButtonComp>
-          <ButtonComp color="primary" icon="edit" @click="editWarehouse">
+          <ButtonComp v-if="auth.isAdmin" color="primary" icon="edit" @click="editWarehouse">
             수정
           </ButtonComp>
         </div>
@@ -26,10 +26,8 @@
     <!-- 상세 정보 -->
     <section v-if="warehouse" class="space-y-8">
       <!-- 기본 정보 -->
-      <div
-          class="bg-zinc-50 dark:bg-zinc-900/40 border border-zinc-200 dark:border-zinc-700
-             rounded-xl shadow-sm p-6 backdrop-blur-sm"
-      >
+      <div class="bg-zinc-50 dark:bg-zinc-900/40 border border-zinc-200 dark:border-zinc-700
+             rounded-xl shadow-sm p-6 backdrop-blur-sm">
         <h2 class="text-lg font-semibold mb-4 text-slate-900 dark:text-white">기본 정보</h2>
 
         <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-x-8 gap-y-4">
@@ -41,10 +39,8 @@
       </div>
 
       <!-- 주소 정보 -->
-      <div
-          class="bg-zinc-50 dark:bg-zinc-900/40 border border-zinc-200 dark:border-zinc-700
-             rounded-xl shadow-sm p-6 backdrop-blur-sm"
-      >
+      <div class="bg-zinc-50 dark:bg-zinc-900/40 border border-zinc-200 dark:border-zinc-700
+             rounded-xl shadow-sm p-6 backdrop-blur-sm">
         <h2 class="text-lg font-semibold mb-4 text-slate-900 dark:text-white">주소 정보</h2>
         <div class="space-y-2">
           <div><span class="text-gray-500 text-sm block">우편번호</span> {{ warehouse.address?.zipcode || '-' }}</div>
@@ -68,10 +64,12 @@ import { useRoute, useRouter } from 'vue-router'
 import AppPageLayout from '@/layouts/AppPageLayout.vue'
 import ButtonComp from '@/components/common/ButtonComp.vue'
 import warehouseApi from '@/api/warehouse/index.js'
+import { useAuthStore } from '@/stores/authStore'
 
 const route = useRoute()
 const router = useRouter()
 const warehouse = ref(null)
+const auth = useAuthStore()
 
 // ✅ 상세 조회
 const getWarehouse = async () => {

--- a/src/views/warehouse/WarehouseList.vue
+++ b/src/views/warehouse/WarehouseList.vue
@@ -13,15 +13,11 @@
         <div class="flex items-center gap-3">
           <!-- 신규 등록 -->
           <RouterLink to="/warehouse/create" class="w-40">
-            <ButtonComp color="primary" icon="add" class="whitespace-nowrap">신규 창고</ButtonComp>
+            <ButtonComp v-if="auth.isAdmin" color="primary" icon="add" class="whitespace-nowrap">신규 창고</ButtonComp>
           </RouterLink>
 
           <!-- 검색창 -->
-          <SearchBarComp
-              v-model="query"
-              placeholder="창고명 또는 이메일 검색..."
-              @search="handleSearch"
-          />
+          <SearchBarComp v-model="query" placeholder="창고명 또는 이메일 검색..." @search="handleSearch" />
         </div>
       </div>
     </template>
@@ -30,10 +26,8 @@
     <TableComp :columns="columns" :data="filteredWarehouses">
       <!-- 창고명 클릭 시 상세로 이동 -->
       <template #cell-name="{ row }">
-        <RouterLink
-            :to="{ name: 'warehouseDetail', params: { id: row.id } }"
-            class="text-blue-600 dark:text-blue-400 hover:underline font-medium"
-        >
+        <RouterLink :to="{ name: 'warehouseDetail', params: { id: row.id } }"
+          class="text-blue-600 dark:text-blue-400 hover:underline font-medium">
           {{ row.name }}
         </RouterLink>
       </template>
@@ -53,6 +47,7 @@ import SearchBarComp from '@/components/common/SearchBarComp.vue'
 import TableComp from '@/components/common/TableComp.vue'
 import ButtonComp from '@/components/common/ButtonComp.vue'
 import warehouseApi from '@/api/warehouse/index.js'
+import { useAuthStore } from '@/stores/authStore'
 
 // ✅ 테이블 컬럼 정의 (id 제거)
 const columns = [
@@ -64,6 +59,7 @@ const columns = [
 
 const warehouses = ref([])
 const query = ref('')
+const auth = useAuthStore()
 
 // ✅ 데이터 조회
 const fetchWarehouses = async () => {
@@ -80,9 +76,9 @@ const filteredWarehouses = computed(() => {
   const q = query.value.trim().toLowerCase()
   if (!q) return warehouses.value
   return warehouses.value.filter((w) =>
-      [w.name, w.email, w.phoneNumber].some((field) =>
-          field?.toLowerCase().includes(q)
-      )
+    [w.name, w.email, w.phoneNumber].some((field) =>
+      field?.toLowerCase().includes(q)
+    )
   )
 })
 


### PR DESCRIPTION
# 🧩 Issue
* #101 
## 📝 요약
> 페이지 권한 별 접근 기능추가 & 수정,등록 버튼 관리자만 보이게 하는 기능.

## 🔍 변경 사항
-권한별로 페이지 접근 할수있게 router에 네비게이션 가드 추가 했고 각각 라우터에 meta추가해 접근 제한뒀습니다.
- pinia authStoer에 isAdmin추가 해 권한 확인해서 수정 등록 삭제 같은 버튼은 관리자만 볼수있게 했습니다.
- 관련 이슈: #이슈번호

## ✅ 체크리스트
- [x] 코드 컨벤션을 준수 했는가?
- [x] 커밋 내용에 시크릿 키 등의 공유되지 말아야 할 것들을 제거 했는가?

## 💬 기타 공유사항
> 프론트에서 권한별 접근 기능추가해서 백도 추가하겠습니다.